### PR TITLE
Complete --script-args based on --script, closes issue #1

### DIFF
--- a/nmap
+++ b/nmap
@@ -152,6 +152,20 @@ _nmap() {
                     $( cd ~/.nmap/scripts/ 2>/dev/null &&
                         compgen -G "*.nse" -X "!$cur*" -- $cur ) )
                 fi
+                ;;
+            --script-args)
+                [ -z "$NMAPDIR" ] && exit 1
+                local script_name=`echo ${COMP_WORDS[*]} | grep -Po -- '--script \K[-_[:alnum:]]*'`
+                if [ -f "$NMAPDIR/scripts/$script_name.nse" ]; then
+                    # Load the script arguments from the db file
+                    IFS=$'\n' read -d '' -r -a lines < "$NMAPDIR/scripts/script-args.db"
+                    for ((i=0; i<${#lines[@]}; i++)); do
+                        if [ ${lines[i]%:*} == ${script_name} ]; then
+                            break;
+                        fi;
+                    done
+                    COMPREPLY=($( compgen -W  "${lines[i]#*:}" -- "$cur" ))
+                fi
                 ;;&
             +(${file_opts// /|}))
                 _filedir


### PR DESCRIPTION
To auto-complete the --script-args based on --script we have to store them initially in our db file.

Inorder for the script to work, create scripts/script-args.db file.
Syntax in the db file: `scriptname:  arg1 arg2 arg3`
For example, the entries should be like
`shodan-api: shodan-api.hostname shodan-api.port shodan-api.host`

Everything else works same as before.